### PR TITLE
chore(deps): removes purell from dependancies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,8 @@
 module github.com/go-openapi/jsonreference
 
 require (
-	github.com/PuerkitoBio/purell v1.1.1
-	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/go-openapi/jsonpointer v0.19.3
 	github.com/stretchr/testify v1.3.0
-	golang.org/x/net v0.0.0-20210421230115-4e50805a0758 // indirect
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-github.com/PuerkitoBio/purell v1.1.1 h1:WEQqlqaGbrPkxLJWfBwQmfEAE1Z7ONdDLqrN38tNFfI=
-github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
-github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 h1:d+Bc7a5rLufV/sSk/8dngufqelfh6jnri85riMAaF/M=
-github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -22,14 +18,6 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-golang.org/x/net v0.0.0-20210421230115-4e50805a0758 h1:aEpZnXcAmXkd6AvLb2OPt+EN1Zu/8Ne3pCqPjja5PXY=
-golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
-golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/internal/normalize_url.go
+++ b/internal/normalize_url.go
@@ -1,0 +1,63 @@
+package internal
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+const (
+	defaultHttpPort  = ":80"
+	defaultHttpsPort = ":443"
+)
+
+// Regular expressions used by the normalizations
+var rxPort = regexp.MustCompile(`(:\d+)/?$`)
+var rxDupSlashes = regexp.MustCompile(`/{2,}`)
+
+// NormalizeURL will normalize the specified URL
+// This was added to replace a previous call to the no longer maintained purell library:
+// The call that was used looked like the following:
+//   url.Parse(purell.NormalizeURL(parsed, purell.FlagsSafe|purell.FlagRemoveDuplicateSlashes))
+//
+// To explain all that was included in the call above, purell.FlagsSafe was really just the following:
+//	  - FlagLowercaseScheme
+//	  - FlagLowercaseHost
+//	  - FlagRemoveDefaultPort
+//	  - FlagRemoveDuplicateSlashes (and this was mixed in with the |)
+func NormalizeURL(u *url.URL) {
+	lowercaseScheme(u)
+	lowercaseHost(u)
+	removeDefaultPort(u)
+	removeDuplicateSlashes(u)
+}
+
+func lowercaseScheme(u *url.URL) {
+	if len(u.Scheme) > 0 {
+		u.Scheme = strings.ToLower(u.Scheme)
+	}
+}
+
+func lowercaseHost(u *url.URL) {
+	if len(u.Host) > 0 {
+		u.Host = strings.ToLower(u.Host)
+	}
+}
+
+func removeDefaultPort(u *url.URL) {
+	if len(u.Host) > 0 {
+		scheme := strings.ToLower(u.Scheme)
+		u.Host = rxPort.ReplaceAllStringFunc(u.Host, func(val string) string {
+			if (scheme == "http" && val == defaultHttpPort) || (scheme == "https" && val == defaultHttpsPort) {
+				return ""
+			}
+			return val
+		})
+	}
+}
+
+func removeDuplicateSlashes(u *url.URL) {
+	if len(u.Path) > 0 {
+		u.Path = rxDupSlashes.ReplaceAllString(u.Path, "/")
+	}
+}

--- a/reference.go
+++ b/reference.go
@@ -30,8 +30,8 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/PuerkitoBio/purell"
 	"github.com/go-openapi/jsonpointer"
+	"github.com/go-openapi/jsonreference/internal"
 )
 
 const (
@@ -114,7 +114,9 @@ func (r *Ref) parse(jsonReferenceString string) error {
 		return err
 	}
 
-	r.referenceURL, _ = url.Parse(purell.NormalizeURL(parsed, purell.FlagsSafe|purell.FlagRemoveDuplicateSlashes))
+	internal.NormalizeURL(parsed)
+
+	r.referenceURL = parsed
 	refURL := r.referenceURL
 
 	if refURL.Scheme != "" && refURL.Host != "" {


### PR DESCRIPTION
This adds an internal implementation of what was consumed from the
`purell` module by copying only the bits that were ultimately
consumed.

All tests still pass.

Issue: #10 