### PR TITLE
Normalize non-encoded utf-8 URL

### DIFF
--- a/internal/normalize_url.go
+++ b/internal/normalize_url.go
@@ -26,11 +26,16 @@ var rxDupSlashes = regexp.MustCompile(`/{2,}`)
 //   - FlagLowercaseHost
 //   - FlagRemoveDefaultPort
 //   - FlagRemoveDuplicateSlashes (and this was mixed in with the |)
+//
+// This also normalizes the URL into its urlencoded form by removing RawPath and RawFragment.
 func NormalizeURL(u *url.URL) {
 	lowercaseScheme(u)
 	lowercaseHost(u)
 	removeDefaultPort(u)
 	removeDuplicateSlashes(u)
+
+	u.RawPath = ""
+	u.RawFragment = ""
 }
 
 func lowercaseScheme(u *url.URL) {

--- a/reference_test.go
+++ b/reference_test.go
@@ -26,6 +26,7 @@
 package jsonreference
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/go-openapi/jsonpointer"
@@ -419,5 +420,19 @@ func TestReferenceResolution(t *testing.T) {
 		if res.String() != expected {
 			t.Errorf("%d: Inherits(%s, %s) %s expected %s", i/2, base, child, res.String(), expected)
 		}
+	}
+}
+
+func TestIdenticalURLEncoded(t *testing.T) {
+	expected, err := New("https://localhost/🌭#/🍔")
+	if err != nil {
+		t.Fatalf("Failed to create jsonreference: %v", err)
+	}
+	actual, err := New("https://localhost/%F0%9F%8C%AD#/%F0%9F%8D%94")
+	if err != nil {
+		t.Fatalf("Failed to create jsonreference: %v", err)
+	}
+	if !reflect.DeepEqual(expected, actual) {
+		t.Fatalf("expected %v (URL: %#v), got %v (URL: %#v)", expected.String(), expected.referenceURL, actual.String(), actual.referenceURL)
 	}
 }


### PR DESCRIPTION
Found out as part of https://github.com/kubernetes/kube-openapi/pull/344
This makes it easier to compare Refs using reflect.DeepEqual.