### PR TITLE
fix(ci): muted warnings in CI runs due to cache conflicts

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           version: latest
           only-new-issues: true
+          skip-cache: true
 
   test:
     name: Unit tests
@@ -38,7 +39,7 @@ jobs:
 
     - uses: actions/checkout@v3
 
-    - run: go test -v -race -coverprofile="coverage-${{ matrix.os }}.${{ matrix.go_version }}.out" -covermode=atomic ./...
+    - run: go test -v -race -coverprofile="coverage-${{ matrix.os }}.${{ matrix.go_version }}.out" -covermode=atomic -coverpkg=$(go list)/... ./...
 
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v3

--- a/internal/normalize_url_test.go
+++ b/internal/normalize_url_test.go
@@ -1,0 +1,39 @@
+package internal
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUrlnorm(t *testing.T) {
+	testCases := []struct {
+		url      string
+		expected string
+	}{
+		{
+			url:      "HTTPs://xYz.cOm:443/folder//file",
+			expected: "https://xyz.com/folder/file",
+		},
+		{
+			url:      "HTTP://xYz.cOm:80/folder//file",
+			expected: "http://xyz.com/folder/file",
+		},
+		{
+			url:      "postGRES://xYz.cOm:5432/folder//file",
+			expected: "postgres://xyz.com:5432/folder/file",
+		},
+	}
+
+	for _, toPin := range testCases {
+		testCase := toPin
+
+		u, err := url.Parse(testCase.url)
+		require.NoError(t, err)
+
+		NormalizeURL(u)
+		assert.Equal(t, testCase.expected, u.String())
+	}
+}


### PR DESCRIPTION
Every time a job is posted, I receive false alarm failure notifications because of some cache conflict during the linting job.

Reference: golangci/golangci-lint-action#807