### PR TITLE
chore: bump go directive to 1.25.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,4 +7,4 @@ require (
 
 require github.com/go-openapi/swag/jsonname v0.25.5 // indirect
 
-go 1.24.0
+go 1.25.0


### PR DESCRIPTION
## Summary

- Update all `go.mod` (and `go.work` where applicable) to require `go 1.25.0`
- Run `go mod tidy` / `go work sync` to update checksums

## Test plan

- [ ] CI passes on all platforms (ubuntu, macos, windows) x (stable, oldstable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)