### PR TITLE
ci: schedule bot PR monitoring

### DIFF
--- a/.github/workflows/monitor-bot-pr.yml
+++ b/.github/workflows/monitor-bot-pr.yml
@@ -1,0 +1,17 @@
+name: Monitor bot PRs
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '18 6 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  monitor-pr:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: go-openapi/ci-workflows/.github/workflows/monitor-bot-pr.yml@ff87261e2ba4b6a01b2b03bf2738b078e064c8c5 # v0.3.0
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds a daily-scheduled workflow that calls the shared `monitor-bot-pr` workflow from `go-openapi/ci-workflows` ([v0.3.0](https://github.com/go-openapi/ci-workflows/releases/tag/v0.3.0), commit `ff87261`).

The shared workflow detects bot PRs (dependabot or organization bot) where auto-merge is enabled but the branch fell behind `master`, and unblocks them:

- dependabot PRs → a `@dependabot rebase` comment;
- organization bot PRs → `gh pr update-branch --rebase`.

Runs daily at 06:18 UTC and on `workflow_dispatch`. PRs from dependency groups that are not configured for auto-merge are excluded automatically (the `autoMergeRequest != null` filter).

## Test plan

- [ ] Trigger the workflow manually via `workflow_dispatch` once merged and observe the notice annotations (`No stalled ... PRs found` or `Requesting dependabot rebase for ...`).
- [ ] Wait for a real stalled PR (BEHIND master, idle ≥ 1 day, auto-merge on) and confirm the next scheduled run unblocks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)